### PR TITLE
chore: upgrade TypeScript to v5 and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"base64-js": "^1.5.1",
 				"lzma": "^2.3.2",
 				"messagepack": "^1.1.12",
-				"typescript": "^4.8.2"
+				"typescript": "^5.8.0"
 			},
 			"devDependencies": {
 				"@vscode/vsce": "^2.30.1-0",
@@ -4088,16 +4088,16 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uc.micro": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.3.0",
 			"license": "MIT",
 			"dependencies": {
-				"@types/node": "^18.7.23",
+				"@types/node": "^22.19.15",
 				"@types/vscode": "^1.71.0",
 				"base64-js": "^1.5.1",
 				"lzma": "^2.3.2",
@@ -17,15 +17,32 @@
 				"typescript": "^5.8.0"
 			},
 			"devDependencies": {
-				"@vscode/vsce": "^2.30.1-0",
+				"@vscode/vsce": "^3.7.1",
 				"clean-webpack-plugin": "^4.0.0",
 				"ts-loader": "^9.5.0",
 				"ts-node": "^10.9.1",
 				"webpack": "^5.104.1",
-				"webpack-cli": "^5.1.4"
+				"webpack-cli": "^7.0.2"
 			},
 			"engines": {
 				"vscode": "^1.75.0"
+			}
+		},
+		"node_modules/@azu/format-text": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+			"integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@azu/style-format": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+			"integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
+			"dev": true,
+			"license": "WTFPL",
+			"dependencies": {
+				"@azu/format-text": "^1.0.1"
 			}
 		},
 		"node_modules/@azure/abort-controller": {
@@ -197,6 +214,31 @@
 				"node": ">=20"
 			}
 		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -211,13 +253,23 @@
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
-			"integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.0.0.tgz",
+			"integrity": "sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=14.17.0"
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+			"integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -290,6 +342,328 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@secretlint/config-creator": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
+			"integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/types": "^10.2.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/config-loader": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
+			"integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/profiler": "^10.2.2",
+				"@secretlint/resolver": "^10.2.2",
+				"@secretlint/types": "^10.2.2",
+				"ajv": "^8.17.1",
+				"debug": "^4.4.1",
+				"rc-config-loader": "^4.1.3"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/core": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
+			"integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/profiler": "^10.2.2",
+				"@secretlint/types": "^10.2.2",
+				"debug": "^4.4.1",
+				"structured-source": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/formatter": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
+			"integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/resolver": "^10.2.2",
+				"@secretlint/types": "^10.2.2",
+				"@textlint/linter-formatter": "^15.2.0",
+				"@textlint/module-interop": "^15.2.0",
+				"@textlint/types": "^15.2.0",
+				"chalk": "^5.4.1",
+				"debug": "^4.4.1",
+				"pluralize": "^8.0.0",
+				"strip-ansi": "^7.1.0",
+				"table": "^6.9.0",
+				"terminal-link": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/formatter/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@secretlint/node": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
+			"integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/config-loader": "^10.2.2",
+				"@secretlint/core": "^10.2.2",
+				"@secretlint/formatter": "^10.2.2",
+				"@secretlint/profiler": "^10.2.2",
+				"@secretlint/source-creator": "^10.2.2",
+				"@secretlint/types": "^10.2.2",
+				"debug": "^4.4.1",
+				"p-map": "^7.0.3"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/node/node_modules/p-map": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@secretlint/profiler": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
+			"integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@secretlint/resolver": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
+			"integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@secretlint/secretlint-formatter-sarif": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
+			"integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"node-sarif-builder": "^3.2.0"
+			}
+		},
+		"node_modules/@secretlint/secretlint-rule-no-dotenv": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
+			"integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/types": "^10.2.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/secretlint-rule-preset-recommend": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
+			"integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/source-creator": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
+			"integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/types": "^10.2.2",
+				"istextorbinary": "^9.5.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@secretlint/types": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
+			"integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@textlint/ast-node-types": {
+			"version": "15.5.2",
+			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.2.tgz",
+			"integrity": "sha512-fCaOxoup5LIyBEo7R1oYWE7V4bSX0KQeHh66twon9e9usaLE3ijgF8QjYsR6joCssdeCHVd0wHm7ppsEyTr6vg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/linter-formatter": {
+			"version": "15.5.2",
+			"resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.5.2.tgz",
+			"integrity": "sha512-jAw7jWM8+wU9cG6Uu31jGyD1B+PAVePCvnPKC/oov+2iBPKk3ao30zc/Itmi7FvXo4oPaL9PmzPPQhyniPVgVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@azu/format-text": "^1.0.2",
+				"@azu/style-format": "^1.0.1",
+				"@textlint/module-interop": "15.5.2",
+				"@textlint/resolver": "15.5.2",
+				"@textlint/types": "15.5.2",
+				"chalk": "^4.1.2",
+				"debug": "^4.4.3",
+				"js-yaml": "^4.1.1",
+				"lodash": "^4.17.23",
+				"pluralize": "^2.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"table": "^6.9.0",
+				"text-table": "^0.2.0"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/pluralize": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+			"integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/linter-formatter/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@textlint/module-interop": {
+			"version": "15.5.2",
+			"resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.5.2.tgz",
+			"integrity": "sha512-mg6rMQ3+YjwiXCYoQXbyVfDucpTa1q5mhspd/9qHBxUq4uY6W8GU42rmT3GW0V1yOfQ9z/iRrgPtkp71s8JzXg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/resolver": {
+			"version": "15.5.2",
+			"resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.5.2.tgz",
+			"integrity": "sha512-YEITdjRiJaQrGLUWxWXl4TEg+d2C7+TNNjbGPHPH7V7CCnXm+S9GTjGAL7Q2WSGJyFEKt88Jvx6XdJffRv4HEA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@textlint/types": {
+			"version": "15.5.2",
+			"resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.5.2.tgz",
+			"integrity": "sha512-sJOrlVLLXp4/EZtiWKWq9y2fWyZlI8GP+24rnU5avtPWBIMm/1w97yzKrAqYF8czx2MqR391z5akhnfhj2f/AQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@textlint/ast-node-types": "15.5.2"
 			}
 		},
 		"node_modules/@tsconfig/node10": {
@@ -375,13 +749,27 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.130",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"version": "22.19.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+			"integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.21.0"
 			}
+		},
+		"node_modules/@types/normalize-package-data": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/sarif": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+			"integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.110.0",
@@ -405,31 +793,36 @@
 			}
 		},
 		"node_modules/@vscode/vsce": {
-			"version": "2.32.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.32.0.tgz",
-			"integrity": "sha512-3EFJfsgrSftIqt3EtdRcAygy/OJ3hstyI1cDmIgkU9CFZW5C+3djr6mfosndCUqcVYuyjmxOK1xmFp/Bq7+NIg==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
+			"integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@azure/identity": "^4.1.0",
+				"@secretlint/node": "^10.1.2",
+				"@secretlint/secretlint-formatter-sarif": "^10.1.2",
+				"@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
+				"@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
 				"@vscode/vsce-sign": "^2.0.0",
 				"azure-devops-node-api": "^12.5.0",
-				"chalk": "^2.4.2",
+				"chalk": "^4.1.2",
 				"cheerio": "^1.0.0-rc.9",
 				"cockatiel": "^3.1.2",
-				"commander": "^6.2.1",
+				"commander": "^12.1.0",
 				"form-data": "^4.0.0",
-				"glob": "^7.0.6",
+				"glob": "^11.0.0",
 				"hosted-git-info": "^4.0.2",
 				"jsonc-parser": "^3.2.0",
 				"leven": "^3.1.0",
-				"markdown-it": "^12.3.2",
+				"markdown-it": "^14.1.0",
 				"mime": "^1.3.4",
 				"minimatch": "^3.0.3",
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
+				"secretlint": "^10.1.2",
 				"semver": "^7.5.2",
-				"tmp": "^0.2.1",
+				"tmp": "^0.2.3",
 				"typed-rest-client": "^1.8.4",
 				"url-join": "^4.0.1",
 				"xml2js": "^0.5.0",
@@ -440,7 +833,7 @@
 				"vsce": "vsce"
 			},
 			"engines": {
-				"node": ">= 16"
+				"node": ">= 20"
 			},
 			"optionalDependencies": {
 				"keytar": "^7.7.0"
@@ -590,6 +983,70 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@vscode/vsce/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/glob": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"foreground-child": "^3.3.1",
+				"jackspeak": "^4.1.1",
+				"minimatch": "^10.1.1",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^2.0.0"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.14.1",
@@ -752,53 +1209,6 @@
 				"@xtuc/long": "4.2.2"
 			}
 		},
-		"node_modules/@webpack-cli/configtest": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
-			"integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.15.0"
-			},
-			"peerDependencies": {
-				"webpack": "5.x.x",
-				"webpack-cli": "5.x.x"
-			}
-		},
-		"node_modules/@webpack-cli/info": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
-			"integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.15.0"
-			},
-			"peerDependencies": {
-				"webpack": "5.x.x",
-				"webpack-cli": "5.x.x"
-			}
-		},
-		"node_modules/@webpack-cli/serve": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
-			"integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.15.0"
-			},
-			"peerDependencies": {
-				"webpack": "5.x.x",
-				"webpack-cli": "5.x.x"
-			},
-			"peerDependenciesMeta": {
-				"webpack-dev-server": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -910,17 +1320,49 @@
 				"ajv": "^8.8.2"
 			}
 		},
-		"node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+		"node_modules/ansi-escapes": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+			"integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"color-convert": "^1.9.0"
+				"environment": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/arg": {
@@ -958,6 +1400,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/asynckit": {
@@ -1018,6 +1470,22 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/binaryextensions": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+			"integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"editions": "^6.21.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
 		"node_modules/bl": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -1037,6 +1505,13 @@
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/boundary": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+			"integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.12",
@@ -1215,18 +1690,20 @@
 			"license": "CC-BY-4.0"
 		},
 		"node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/cheerio": {
@@ -1333,26 +1810,22 @@
 			}
 		},
 		"node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"color-name": "1.1.3"
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
 			}
 		},
 		"node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/colorette": {
-			"version": "2.0.20",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1370,13 +1843,13 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 6"
+				"node": ">=18"
 			}
 		},
 		"node_modules/concat-map": {
@@ -1661,12 +2134,36 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/editions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+			"integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"version-range": "^4.15.0"
+			},
+			"engines": {
+				"ecmascript": ">= es5",
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.321",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
 			"integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/encoding-sniffer": {
 			"version": "0.2.1",
@@ -1733,6 +2230,19 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/environment": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/es-define-property": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1797,16 +2307,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -1884,6 +2384,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-glob": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.8"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
 		"node_modules/fast-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -1909,6 +2426,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4.9.1"
+			}
+		},
+		"node_modules/fastq": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"reusify": "^1.0.4"
 			}
 		},
 		"node_modules/fd-slicer": {
@@ -1958,6 +2485,23 @@
 				"flat": "cli.js"
 			}
 		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/form-data": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -1982,6 +2526,21 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/fs-extra": {
+			"version": "11.3.4",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+			"integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -2069,6 +2628,19 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/glob-to-regexp": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -2124,13 +2696,13 @@
 			"license": "ISC"
 		},
 		"node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/has-symbols": {
@@ -2284,6 +2856,16 @@
 			"license": "BSD-3-Clause",
 			"optional": true
 		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/import-local": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -2299,6 +2881,19 @@
 			},
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/index-to-position": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+			"integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -2371,6 +2966,39 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-inside-container": {
@@ -2484,6 +3112,40 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/istextorbinary": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+			"integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"binaryextensions": "^6.11.0",
+				"editions": "^6.21.0",
+				"textextensions": "^6.11.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+			"integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^9.0.0"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/jest-worker": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -2497,16 +3159,6 @@
 			},
 			"engines": {
 				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/jest-worker/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/jest-worker/node_modules/supports-color": {
@@ -2525,6 +3177,26 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/js-yaml": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2539,12 +3211,38 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/jsonc-parser": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
 			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"node_modules/jsonwebtoken": {
 			"version": "9.0.3",
@@ -2626,13 +3324,13 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-			"integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"uc.micro": "^1.0.1"
+				"uc.micro": "^2.0.0"
 			}
 		},
 		"node_modules/loader-runner": {
@@ -2661,6 +3359,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
@@ -2711,6 +3416,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lodash.truncate": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2741,30 +3453,21 @@
 			"license": "ISC"
 		},
 		"node_modules/markdown-it": {
-			"version": "12.3.2",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-			"integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+			"integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1",
-				"entities": "~2.1.0",
-				"linkify-it": "^3.0.1",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
 			},
 			"bin": {
-				"markdown-it": "bin/markdown-it.js"
-			}
-		},
-		"node_modules/markdown-it/node_modules/entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
+				"markdown-it": "bin/markdown-it.mjs"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -2778,9 +3481,9 @@
 			}
 		},
 		"node_modules/mdurl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2790,6 +3493,16 @@
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
 		},
 		"node_modules/messagepack": {
 			"version": "1.1.12",
@@ -2885,6 +3598,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
 		"node_modules/mkdirp-classic": {
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -2950,6 +3673,55 @@
 			"integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/node-sarif-builder": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+			"integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/sarif": "^2.1.7",
+				"fs-extra": "^11.1.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/normalize-package-data": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/normalize-package-data/node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/normalize-package-data/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",
@@ -3063,6 +3835,31 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/parse-json": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"index-to-position": "^1.1.0",
+				"type-fest": "^4.39.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/parse-semver": {
@@ -3182,6 +3979,46 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "11.2.7",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+			"integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/path-type": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+			"integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -3255,6 +4092,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -3296,6 +4143,16 @@
 				"once": "^1.3.1"
 			}
 		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/qs": {
 			"version": "6.15.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
@@ -3311,6 +4168,27 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/rc": {
 			"version": "1.2.8",
@@ -3329,6 +4207,19 @@
 				"rc": "cli.js"
 			}
 		},
+		"node_modules/rc-config-loader": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+			"integrity": "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"js-yaml": "^4.1.1",
+				"json5": "^2.2.3",
+				"require-from-string": "^2.0.2"
+			}
+		},
 		"node_modules/read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -3340,6 +4231,26 @@
 			},
 			"engines": {
 				"node": ">=0.8"
+			}
+		},
+		"node_modules/read-pkg": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.3",
+				"normalize-package-data": "^6.0.0",
+				"parse-json": "^8.0.0",
+				"type-fest": "^4.6.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/readable-stream": {
@@ -3425,6 +4336,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/reusify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/rimraf": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -3450,6 +4372,30 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -3508,6 +4454,62 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/secretlint": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
+			"integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@secretlint/config-creator": "^10.2.2",
+				"@secretlint/formatter": "^10.2.2",
+				"@secretlint/node": "^10.2.2",
+				"@secretlint/profiler": "^10.2.2",
+				"debug": "^4.4.1",
+				"globby": "^14.1.0",
+				"read-pkg": "^9.0.1"
+			},
+			"bin": {
+				"secretlint": "bin/secretlint.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/secretlint/node_modules/globby": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+			"integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.3",
+				"ignore": "^7.0.3",
+				"path-type": "^6.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/secretlint/node_modules/unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/semver": {
@@ -3635,6 +4637,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/simple-concat": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -3684,6 +4699,37 @@
 				"simple-concat": "^1.0.0"
 			}
 		},
+		"node_modules/slash": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
 		"node_modules/source-map": {
 			"version": "0.7.6",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -3715,6 +4761,42 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/spdx-correct": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-exceptions": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+			"dev": true,
+			"license": "CC-BY-3.0"
+		},
+		"node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-license-ids": {
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+			"dev": true,
+			"license": "CC0-1.0"
+		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3724,6 +4806,60 @@
 			"optional": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -3737,17 +4873,44 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/structured-source": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+			"integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boundary": "^2.0.0"
+			}
+		},
 		"node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"has-flag": "^3.0.0"
+				"has-flag": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-hyperlinks": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -3761,6 +4924,46 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/table": {
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+			"integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"ajv": "^8.0.1",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/table/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/table/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/tapable": {
@@ -3807,6 +5010,23 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/terminal-link": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+			"integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^7.0.0",
+				"supports-hyperlinks": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/terser": {
@@ -3880,6 +5100,29 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/textextensions": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+			"integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"editions": "^6.21.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
 		"node_modules/tmp": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -3922,82 +5165,6 @@
 			"peerDependencies": {
 				"typescript": "*",
 				"webpack": "^5.0.0"
-			}
-		},
-		"node_modules/ts-loader/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/ts-loader/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/ts-loader/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/ts-loader/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ts-loader/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ts-loader/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/ts-node": {
@@ -4075,6 +5242,19 @@
 				"node": "*"
 			}
 		},
+		"node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/typed-rest-client": {
 			"version": "1.8.11",
 			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
@@ -4101,9 +5281,9 @@
 			}
 		},
 		"node_modules/uc.micro": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4125,10 +5305,33 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"license": "MIT"
+		},
+		"node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.2.3",
@@ -4192,6 +5395,30 @@
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"node_modules/version-range": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+			"integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
 		},
 		"node_modules/watchpack": {
 			"version": "2.5.1",
@@ -4257,43 +5484,38 @@
 			}
 		},
 		"node_modules/webpack-cli": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
-			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.2.tgz",
+			"integrity": "sha512-dB0R4T+C/8YuvM+fabdvil6QE44/ChDXikV5lOOkrUeCkW5hTJv2pGLE3keh+D5hjYw8icBaJkZzpFoaHV4T+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^2.1.1",
-				"@webpack-cli/info": "^2.0.2",
-				"@webpack-cli/serve": "^2.0.5",
-				"colorette": "^2.0.14",
-				"commander": "^10.0.1",
-				"cross-spawn": "^7.0.3",
-				"envinfo": "^7.7.3",
+				"@discoveryjs/json-ext": "^1.0.0",
+				"commander": "^14.0.3",
+				"cross-spawn": "^7.0.6",
+				"envinfo": "^7.14.0",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",
 				"interpret": "^3.1.1",
 				"rechoir": "^0.8.0",
-				"webpack-merge": "^5.7.3"
+				"webpack-merge": "^6.0.1"
 			},
 			"bin": {
 				"webpack-cli": "bin/cli.js"
 			},
 			"engines": {
-				"node": ">=14.15.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "5.x.x"
+				"webpack": "^5.101.0",
+				"webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
+				"webpack-dev-server": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
-				"@webpack-cli/generators": {
-					"optional": true
-				},
 				"webpack-bundle-analyzer": {
 					"optional": true
 				},
@@ -4303,28 +5525,28 @@
 			}
 		},
 		"node_modules/webpack-cli/node_modules/commander": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=14"
+				"node": ">=20"
 			}
 		},
 		"node_modules/webpack-merge": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-			"integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+			"integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"clone-deep": "^4.0.1",
 				"flat": "^5.0.2",
-				"wildcard": "^2.0.0"
+				"wildcard": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		}
 	},
 	"dependencies": {
-		"@types/node": "^18.7.23",
+		"@types/node": "^22.19.15",
 		"@types/vscode": "^1.71.0",
 		"base64-js": "^1.5.1",
 		"lzma": "^2.3.2",
@@ -110,11 +110,11 @@
 		"test": "echo \"No tests\""
 	},
 	"devDependencies": {
-		"@vscode/vsce": "^2.30.1-0",
+		"@vscode/vsce": "^3.7.1",
 		"clean-webpack-plugin": "^4.0.0",
 		"ts-loader": "^9.5.0",
 		"ts-node": "^10.9.1",
 		"webpack": "^5.104.1",
-		"webpack-cli": "^5.1.4"
+		"webpack-cli": "^7.0.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"base64-js": "^1.5.1",
 		"lzma": "^2.3.2",
 		"messagepack": "^1.1.12",
-		"typescript": "^4.8.2"
+		"typescript": "^5.8.0"
 	},
 	"scripts": {
 		"build": "npm ci --prefix webview && npm run build-webpack-desktop && npm run build-webpack-web && npm run bundle",


### PR DESCRIPTION
Upgrades the `typescript` devDependency from `^4.8.2` to `^5.8.0`, and updates other dependencies to their latest major versions.

TypeScript 5.x brings significant improvements including decorators (stage 3), `const` type parameters, variadic tuple types improvements, and better performance. See the <a href="https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/">TypeScript 5.0 release notes</a> for details.

Additionally, the following dependencies have been updated to their latest major versions:

- `@types/node`: `^18.7.23` → `^22.19.15`
- `@vscode/vsce`: `^2.30.1-0` → `^3.7.1`
- `webpack-cli`: `^5.1.4` → `^7.0.2`

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.